### PR TITLE
Ref: #3, Add third-party licenses NOTICE (colorama)

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -1,0 +1,39 @@
+Este proyecto usa librerías de terceros que son necesarias para su funcionamiento. A continuación se listan las librerías:
+
+# [Colorama](https://pypi.org/project/colorama/)
+
+- Desde `chromolog v0.2.5` se comenzó a usar `colorama v0.4.6` para la compatibilidad de colores en Windows.
+
+
+> [!IMPORTANT]
+> Enlace a la licencia de Colorama original: [LICENSE](https://github.com/tartley/colorama/blob/master/LICENSE.txt)
+
+```plain-text
+Copyright (c) 2010 Jonathan Hartley
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holders, nor those of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```


### PR DESCRIPTION
Se añadió la licencia de código abierto de la dependencia ["colorama"](https://pypi.org/project/colorama/), la cual se empezó a usar desde la versión `v0.2.5` de `chromolog` (este módulo)